### PR TITLE
Change puma port to 3001

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3001 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## Objective
Change development port from http://localhost:3000 to http://localhost:3001 so as to keep port 3000 available for the frontend server.
<!-- Describe the background and target of this PR -->
