### PR TITLE
Install rack-cors to receive requests from frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma', '~> 5.0'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 gem 'devise'
 gem 'devise_token_auth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.3.1)
@@ -174,6 +176,7 @@ DEPENDENCIES
   listen (~> 3.3)
   mysql2 (~> 0.5)
   puma (~> 5.0)
+  rack-cors
   rails (~> 6.1.3, >= 6.1.3.1)
   spring
   tzinfo-data

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV['CLIENT_URL'] 
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end


### PR DESCRIPTION
## Objective
Install rack-cors to receive requests from frontend server.
<!-- Describe the background and target of this PR -->

## What was changed
* Install rack-cors gem
* Restricted origin to CLIENT_URL environment variable
* Added `credentials: true` to allow cookie usage for auth
<!-- Explain in detail what was changed in this PR -->

## What was not changed

<!-- Explain if something is left out of the scope of this PR -->
